### PR TITLE
CMake based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,83 @@
+project (RJObject C CXX)
+cmake_minimum_required (VERSION 2.8.0)
+
+# Setting this explicitly avoids warnings from versions of CMake >= 3
+# regarding policy CMP0042; it should be ignored versions of CMake which don't
+# support it. (Setting the policy explicitly will break with old CMakes.)
+set (CMAKE_MACOSX_RPATH TRUE)
+
+set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+set (CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic")
+set (CMAKE_CXX_FLAGS_RELEASE "-m64 -Ofast -flto -march=native -funroll-loops")
+set (CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
+if (NOT CMAKE_BUILD_TYPE)
+    set (CMAKE_BUILD_TYPE "release")
+endif (NOT CMAKE_BUILD_TYPE)
+
+# Initialize the dependencies to an empty list.
+set (RJOBJ_DEPS)
+
+# ==========================================================================
+#                                                                     DNest3
+# ==========================================================================
+
+find_package (DNest3 REQUIRED)
+list (APPEND RJOBJ_DEPS ${DNEST3_LIBRARY})
+include_directories (SYSTEM ${DNEST3_INCLUDES})
+
+# ==========================================================================
+#                                                                        GSL
+# ==========================================================================
+
+find_package (GSL REQUIRED)
+list (APPEND RJOBJ_DEPS ${GSL_LIBRARIES})
+include_directories (SYSTEM ${GSL_INCLUDES})
+
+# ==========================================================================
+#                                                                      BOOST
+# ==========================================================================
+
+find_package (Boost COMPONENTS thread system REQUIRED)
+list (APPEND RJOBJ_DEPS ${Boost_LIBRARIES})
+include_directories (SYSTEM ${Boost_INCLUDES})
+
+# ==========================================================================
+#                                                                THE LIBRARY
+# ==========================================================================
+
+set (RJOBJ_SRC
+     Distributions/BasicCircular.cpp
+     Distributions/ClassicMassInf.cpp
+     Distributions/Distribution.cpp
+     Distributions/Pareto.cpp
+)
+
+set (RJOBJ_INCLUDES
+     Distributions/BasicCircular.h
+     Distributions/ClassicMassInf.h
+     Distributions/Distribution.h
+     Distributions/Pareto.h
+)
+
+add_library (rjobject ${RJOBJ_SRC})
+target_link_libraries (rjobject ${RJOBJ_DEPS})
+
+install (TARGETS rjobject DESTINATION lib)
+install (FILES ${RJOBJ_INCLUDES} DESTINATION include/rjobject)
+
+# ==========================================================================
+#                                                            DEMO EXECUTABLE
+# ==========================================================================
+
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
+add_executable (main main.cpp)
+target_link_libraries (main rjobject ${RJOBJ_DEPS})
+
+# ==========================================================================
+#                                                               THE EXAMPLES
+# ==========================================================================
+
+# The examples refer to the headers relative to the project root directory.
+include_directories (${PROJECT_SOURCE_DIR})
+add_subdirectory (Examples)

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory (GalaxyField)
+add_subdirectory (Mixture)
+add_subdirectory (SineWaves)

--- a/Examples/GalaxyField/CMakeLists.txt
+++ b/Examples/GalaxyField/CMakeLists.txt
@@ -1,0 +1,4 @@
+set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+add_executable (GalaxyField Data.cpp MyDistribution.cpp MyModel.cpp main.cpp)
+set_target_properties (GalaxyField PROPERTIES OUTPUT_NAME main)
+target_link_libraries (GalaxyField rjobject ${RJOBJ_DEPS})

--- a/Examples/Mixture/CMakeLists.txt
+++ b/Examples/Mixture/CMakeLists.txt
@@ -1,0 +1,4 @@
+set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+add_executable (Mixture Data.cpp MyDistribution.cpp MyModel.cpp main.cpp)
+set_target_properties (Mixture PROPERTIES OUTPUT_NAME main)
+target_link_libraries (Mixture rjobject ${RJOBJ_DEPS})

--- a/Examples/SineWaves/CMakeLists.txt
+++ b/Examples/SineWaves/CMakeLists.txt
@@ -1,0 +1,4 @@
+set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+add_executable (SineWaves Data.cpp MyDistribution.cpp MyModel.cpp main.cpp)
+set_target_properties (SineWaves PROPERTIES OUTPUT_NAME main)
+target_link_libraries (SineWaves rjobject ${RJOBJ_DEPS})

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Reversible Jump Objects
------------------------
+=======================
 
-Classes for generic birth/death MCMC in DNest3.
+Classes for generic birth/death MCMC in
+[DNest3](https://github.com/eggplantbren/DNest3).
 
 (c) 2013 Brendon J. Brewer
 
@@ -9,3 +10,56 @@ Licence: GNU GPL v3 for software, CC BY-NC-SA for documents.
 
 This work is supported by a Marsden Fast-Start grant
 from the Royal Society of New Zealand.
+
+Installation
+============
+
+Building RJObject requires that you have the following packages installed:
+
+* [GNU Scientific Library (GSL)](http://www.gnu.org/software/gsl/)
+* [Boost](http://www.boost.org/)
+* [CMake](http://www.cmake.org/)
+* [DNest3](https://github.com/eggplantbren/DNest3)
+
+The first three can be most conveniently installed using your favourite
+package management system (e.g. [Homebrew](http://mxcl.github.com/homebrew/)
+or [Macports](https://www.macports.org/) on a Mac, APT on
+[Ubuntu](http://www.ubuntu.com/) or [Debian](http://www.debian.org/)). DNest3
+should be compiled and installed following its documentation.
+
+You can then build RJObject as follows:
+
+```
+git clone https://github.com/eggplantbren/RJObject.git
+mkdir RJObject/build
+cd RJObject/build
+cmake ..
+make
+make install
+```
+
+This will install the RJObject library and header files into `/usr/local`,
+while example programs are available in `RJObject/Examples`. If required,
+change the installation location by giving a `-DCMAKE_INSTALL_PREFIX` option
+to CMake:
+
+```
+cmake -DCMAKE_INSTALL_PREFIX=/tmp ..
+```
+
+This procedure assumes that DNest3 has been installed into a standard system
+location. If you have installed it elsewhere (say, `/tmp/dnest`), specify the
+location as follows:
+
+```
+cmake -DNEST3_ROOT_DIR=/tmp/dnest ..
+```
+
+It is also possible to build against a copy of DNest3 which has not been
+installed (but has, of course, been compiled) by directly specifying the
+location of the library and headers. Assuming it has been downloaded and built
+(as a static library, which is the default) in `/home/username/DNest3`:
+
+```
+cmake -DDNEST3_INCLUDES=/home/username/DNest3/include -DDNEST3_LIBRARY=/home/username/DNest3/build/libdnest3.a ..
+```

--- a/cmake/FindDNest3.cmake
+++ b/cmake/FindDNest3.cmake
@@ -1,0 +1,18 @@
+find_path (DNEST3_INCLUDES
+    NAMES "MTSampler.h"
+    PATH_SUFFIXES "/include" "include/dnest3"
+    HINTS ${DNEST3_ROOT_DIR}
+)
+
+find_library (DNEST3_LIBRARY
+    NAMES dnest3
+    PATH_SUFFIXES "/lib"
+    HINTS ${DNEST3_ROOT_DIR}
+)
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (DNest3
+    DEFAULT_MESG
+    DNEST3_INCLUDES
+    DNEST3_LIBRARY
+)

--- a/cmake/FindGSL.cmake
+++ b/cmake/FindGSL.cmake
@@ -1,0 +1,24 @@
+find_path (GSL_INCLUDES
+    NAMES "gsl/gsl_randist.h" "gsl/gsl_rng.h"
+    PATH_SUFFIXES "/include"
+)
+
+find_library (GSL_LIB
+    NAMES gsl
+    PATH_SUFFIXES "/lib"
+)
+list (APPEND GSL_LIBRARIES ${GSL_LIB})
+
+find_library (GSLCBLAS_LIB
+    NAMES gslcblas
+    PATH_SUFFIXES "/lib"
+)
+list (APPEND GSL_LIBRARIES ${GSLCBLAS_LIB})
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (GSL
+    DEFAULT_MESG
+    GSL_INCLUDES
+    GSL_LIB
+    GSLCBLAS_LIB
+)


### PR DESCRIPTION
Unfortunately, since we don't know how the user has installed DNest3 (but can assume it's not through a package manager), it's hard to make this completely bulletproof. I think this will do the right thing in most circumstances though.

By analogy with DNest3, I have build the executables in the source tree, and do not install them when you `make install`.
