### PR TITLE
Some minor changes to the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set (CMAKE_MACOSX_RPATH TRUE)
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 set (CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic")
-set (CMAKE_CXX_FLAGS_RELEASE "-m64 -Ofast -flto -march=native -funroll-loops")
+set (CMAKE_CXX_FLAGS_RELEASE "-m64 -O3 -flto -march=native -funroll-loops")
 set (CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 if (NOT CMAKE_BUILD_TYPE)
     set (CMAKE_BUILD_TYPE "release")
@@ -58,6 +58,8 @@ set (RJOBJ_INCLUDES
      Distributions/ClassicMassInf.h
      Distributions/Distribution.h
      Distributions/Pareto.h
+     RJObject.h
+     RJObjectImpl.h
 )
 
 add_library (rjobject ${RJOBJ_SRC})

--- a/RJObjectImpl.h
+++ b/RJObjectImpl.h
@@ -1,8 +1,8 @@
 #include <cmath>
 #include <iostream>
 #include <iomanip>
-#include "RandomNumberGenerator.h"
-#include "Utils.h"
+#include <RandomNumberGenerator.h>
+#include <Utils.h>
 
 template<class Distribution>
 RJObject<Distribution>::RJObject(int num_dimensions, int max_num_components, bool fixed,


### PR DESCRIPTION
This request is following the discussion on #2 and #1. It
- adds `RJObject.h` and `RJObjectImpl.h` to the installed build
- changes `-Ofast` to `-O3` in the cmake build
- encases the included DNest3 headers `RJObjectImpl.h` in `< >` rather than quotes
