### PR TITLE
Linkage issues with gcc 4.9.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,12 @@ set (CMAKE_MACOSX_RPATH TRUE)
 
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
-set (CMAKE_AR "gcc-ar")
-set (CMAKE_RANLIB "gcc-ranlib")
+if (CMAKE_COMPILER_IS_GNUCC)
+  # if using gcc use gcc-ar and gcc-ranlib rather than ar and ranlib
+  set (CMAKE_AR "gcc-ar")
+  set (CMAKE_RANLIB "gcc-ranlib")
+endif (CMAKE_COMPILER_IS_GNUCC)
+
 set (CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic")
 set (CMAKE_CXX_FLAGS_RELEASE "-m64 -O3 -flto -march=native -funroll-loops")
 set (CMAKE_CXX_FLAGS_DEBUG "-O0 -g")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set (CMAKE_MACOSX_RPATH TRUE)
 
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
+set (CMAKE_AR "gcc-ar")
+set (CMAKE_RANLIB "gcc-ranlib")
 set (CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic")
 set (CMAKE_CXX_FLAGS_RELEASE "-m64 -O3 -flto -march=native -funroll-loops")
 set (CMAKE_CXX_FLAGS_DEBUG "-O0 -g")


### PR DESCRIPTION
There appear to be linkage issues (with [LTO](https://gcc.gnu.org/wiki/LinkTimeOptimization)) when compiling with gcc 4.9.2 (maybe any gcc > 4.8, but I'm not sure) - basically `main` will not compile when trying to link to the files in `Distributions` using `ar`.  This seems to be fixed by using seting `CMAKE_AR` and `CMAKE_RANLIB` to `gcc-ar` and `gcc-ranlib` rather than `ar` and `ranlib`. This fix definitely still works using gcc 4.9.2 and 4.8.4, however I'm not sure if it would break things for `clang`, although hopefully the `if` statement would stop any problems.
